### PR TITLE
update punctuation_cn_to_en.sh  On MacOS

### DIFF
--- a/punctuation_cn_to_en.sh
+++ b/punctuation_cn_to_en.sh
@@ -51,7 +51,7 @@ punctuation_zh_arr[25]='＿'
 punctuation_zh_arr[26]='…'
 punctuation_zh_arr[27]='—'
 punctuation_zh_arr[28]='﹏'
-punctuation_zh_arr[29]='–'
+punctuation_zh_arr[0]='–'
 
 punctuation_en_arr[1]="."
 punctuation_en_arr[2]="?"
@@ -81,7 +81,7 @@ punctuation_en_arr[25]='_'
 punctuation_en_arr[26]='...'
 punctuation_en_arr[27]='-'
 punctuation_en_arr[28]='_'
-punctuation_en_arr[29]='--'
+punctuation_en_arr[0]='--'
 
 
 replace_punctuation() {
@@ -91,7 +91,7 @@ replace_punctuation() {
         if [ "$(uname)" == "Darwin" ]; then
             for i in "${!punctuation_zh_arr[@]}"
             do
-                sed -i '' "s/${punctuation_zh_arr[$i]}/${punctuation_en_arr[$i]}/g" $line
+                sed -i'' "s/${punctuation_zh_arr[$i]}/${punctuation_en_arr[$i]}/g" $line
             done
         elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
             for i in "${!punctuation_zh_arr[@]}"


### PR DESCRIPTION
1. change "sed -i '' " to "sed -i'' " : in MacOS 10.9+.  there no need other space after "-i"
2. change array index ,begin with 0 , for somehow reason . 
all change work on   mac12.2  + bash +  gnu-sed